### PR TITLE
trend goroutine -> 42347

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/labstack/echo/v4 v4.3.0
 	github.com/labstack/gommon v0.3.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/sync v0.3.0
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -42,6 +42,8 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
trendはぐっと下がったけど、全体は変わらず

```
+-------+-----+-------+-----+-----+-----+--------+------------------------------+-------+-------+---------+-------+-------+-------+-------+--------+------------+------------+---------------+------------+
| COUNT | 1XX |  2XX  | 3XX | 4XX | 5XX | METHOD |             URI              |  MIN  |  MAX  |   SUM   |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY)  | MAX(BODY)  |   SUM(BODY)   | AVG(BODY)  |
+-------+-----+-------+-----+-----+-----+--------+------------------------------+-------+-------+---------+-------+-------+-------+-------+--------+------------+------------+---------------+------------+
| 76162 | 0   | 76151 | 0   | 11  | 0   | POST   | /api/condition/[0-9a-z\-]+   | 0.004 | 0.088 | 445.612 | 0.006 | 0.016 | 0.020 | 0.036 | 0.008  | 0.000      | 14.000     | 42.000        | 0.001      |
| 36427 | 0   | 35496 | 0   | 931 | 0   | GET    | /api/isu/[0-9a-z\-]+         | 0.008 | 0.068 | 368.024 | 0.010 | 0.020 | 0.024 | 0.036 | 0.007  | 0.000      | 135259.000 | 746022794.000 | 20479.941  |
| 764   | 0   | 692   | 0   | 1   | 71  | GET    | /api/trend                   | 0.004 | 0.512 | 141.952 | 0.186 | 0.284 | 0.320 | 0.396 | 0.082  | 0.000      | 8196.000   | 5403097.000   | 7072.116   |
| 7297  | 0   | 6711  | 0   | 586 | 0   | GET    | /api/condition/[0-9a-z\-]+   | 0.004 | 0.080 | 114.820 | 0.016 | 0.032 | 0.036 | 0.048 | 0.011  | 0.000      | 6883.000   | 33596714.000  | 4604.182   |
| 3889  | 0   | 3805  | 0   | 84  | 0   | GET    | /api/isu                     | 0.004 | 0.080 | 75.192  | 0.019 | 0.032 | 0.040 | 0.052 | 0.011  | 3.000      | 4627.000   | 12471895.000  | 3206.967   |
| 1668  | 0   | 996   | 0   | 672 | 0   | POST   | /api/auth                    | 0.008 | 0.032 | 10.088  | 0.006 | 0.012 | 0.016 | 0.020 | 0.005  | 0.000      | 19.000     | 7728.000      | 4.633      |
| 1563  | 0   | 744   | 0   | 819 | 0   | GET    | /api/user/me                 | 0.004 | 0.032 | 6.200   | 0.004 | 0.008 | 0.012 | 0.020 | 0.004  | 21.000     | 48.000     | 45517.000     | 29.122     |
| 1598  | 0   | 1512  | 86  | 0   | 0   | GET    | /                            | 0.004 | 0.020 | 4.492   | 0.003 | 0.008 | 0.008 | 0.012 | 0.003  | 528.000    | 528.000    | 798336.000    | 499.584    |
| 823   | 0   | 737   | 0   | 86  | 0   | POST   | /api/signout                 | 0.004 | 0.024 | 4.328   | 0.005 | 0.012 | 0.012 | 0.020 | 0.004  | 0.000      | 21.000     | 1806.000      | 2.194      |
| 886   | 0   | 768   | 118 | 0   | 0   | GET    | /assets/vendor.ee7444dd.js   | 0.000 | 0.036 | 3.824   | 0.004 | 0.008 | 0.012 | 0.016 | 0.004  | 743417.000 | 743417.000 | 570944256.000 | 644406.609 |
| 55    | 0   | 51    | 0   | 4   | 0   | POST   | /api/isu                     | 0.056 | 0.112 | 3.316   | 0.060 | 0.072 | 0.104 | 0.112 | 0.020  | 15.000     | 148.000    | 7096.000      | 129.018    |
| 886   | 0   | 768   | 118 | 0   | 0   | GET    | /assets/favicon.d0f5f504.svg | 0.000 | 0.028 | 3.108   | 0.004 | 0.008 | 0.012 | 0.016 | 0.004  | 592.000    | 592.000    | 454656.000    | 513.156    |
| 886   | 0   | 768   | 118 | 0   | 0   | GET    | /assets/index.23dac98b.js    | 0.000 | 0.028 | 3.084   | 0.003 | 0.008 | 0.008 | 0.016 | 0.004  | 26667.000  | 26667.000  | 20480256.000  | 23115.413  |
| 886   | 0   | 767   | 118 | 1   | 0   | GET    | /assets/logo_white.svg       | 0.012 | 0.024 | 2.960   | 0.003 | 0.008 | 0.008 | 0.016 | 0.003  | 0.000      | 3285.000   | 2519595.000   | 2843.787   |
| 767   | 0   | 767   | 0   | 0   | 0   | GET    | /assets/logo_orange.svg      | 0.004 | 0.024 | 2.732   | 0.004 | 0.008 | 0.012 | 0.016 | 0.004  | 3288.000   | 3288.000   | 2521896.000   | 3288.000   |
| 886   | 0   | 768   | 118 | 0   | 0   | GET    | /assets/index.144d8ca8.css   | 0.000 | 0.020 | 2.620   | 0.003 | 0.008 | 0.008 | 0.016 | 0.004  | 19066.000  | 19066.000  | 14642688.000  | 16526.736  |
| 1     | 0   | 1     | 0   | 0   | 0   | POST   | /initialize                  | 0.220 | 0.220 | 0.220   | 0.220 | 0.220 | 0.220 | 0.220 | 0.000  | 23.000     | 23.000     | 23.000        | 23.000     |
| 3     | 0   | 1     | 2   | 0   | 0   | GET    | /register                    | 0.004 | 0.004 | 0.004   | 0.001 | 0.004 | 0.004 | 0.004 | 0.002  | 0.000      | 528.000    | 528.000       | 176.000    |
| 30    | 0   | 18    | 12  | 0   | 0   | GET    | /isu/[0-9a-z\-]+             | 0.000 | 0.000 | 0.000   | 0.000 | 0.000 | 0.000 | 0.000 | 0.000  | 0.000      | 528.000    | 9504.000      | 316.800    |
+-------+-----+-------+-----+-----+-----+--------+------------------------------+-------+-------+---------+-------+-------+-------+-------+--------+------------+------------+---------------+------------+
```

が

```
+-------+-----+-------+-----+-----+-----+--------+------------------------------+-------+-------+---------+-------+-------+-------+-------+--------+------------+------------+---------------+------------+
| COUNT | 1XX |  2XX  | 3XX | 4XX | 5XX | METHOD |             URI              |  MIN  |  MAX  |   SUM   |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY)  | MAX(BODY)  |   SUM(BODY)   | AVG(BODY)  |
+-------+-----+-------+-----+-----+-----+--------+------------------------------+-------+-------+---------+-------+-------+-------+-------+--------+------------+------------+---------------+------------+
| 76144 | 0   | 76131 | 0   | 13  | 0   | POST   | /api/condition/[0-9a-z\-]+   | 0.000 | 0.100 | 406.987 | 0.005 | 0.012 | 0.020 | 0.036 | 0.007  | 0.000      | 14.000     | 28.000        | 0.000      |
| 35853 | 0   | 34908 | 0   | 945 | 0   | GET    | /api/isu/[0-9a-z\-]+         | 0.004 | 0.076 | 344.118 | 0.010 | 0.020 | 0.024 | 0.036 | 0.007  | 0.000      | 135259.000 | 747955261.000 | 20861.720  |
| 7403  | 0   | 6805  | 0   | 598 | 0   | GET    | /api/condition/[0-9a-z\-]+   | 0.008 | 0.088 | 117.534 | 0.016 | 0.032 | 0.036 | 0.048 | 0.011  | 0.000      | 7100.000   | 34502764.000  | 4660.646   |
| 3827  | 0   | 3742  | 0   | 85  | 0   | GET    | /api/isu                     | 0.004 | 0.108 | 82.496  | 0.022 | 0.040 | 0.048 | 0.064 | 0.014  | 3.000      | 10000.000  | 12393539.000  | 3238.448   |
| 729   | 0   | 728   | 0   | 1   | 0   | GET    | /api/trend                   | 0.004 | 0.116 | 34.640  | 0.048 | 0.072 | 0.080 | 0.100 | 0.017  | 0.000      | 8204.000   | 5580143.000   | 7654.517   |
| 1644  | 0   | 964   | 0   | 680 | 0   | POST   | /api/auth                    | 0.008 | 0.044 | 11.476  | 0.007 | 0.016 | 0.016 | 0.024 | 0.006  | 0.000      | 19.000     | 7820.000      | 4.757      |
| 1493  | 0   | 708   | 0   | 785 | 0   | GET    | /api/user/me                 | 0.004 | 0.056 | 7.576   | 0.005 | 0.012 | 0.016 | 0.024 | 0.006  | 0.000      | 45.000     | 43897.000     | 29.402     |
| 788   | 0   | 701   | 0   | 87  | 0   | POST   | /api/signout                 | 0.004 | 0.040 | 3.888   | 0.005 | 0.012 | 0.016 | 0.020 | 0.005  | 0.000      | 21.000     | 1827.000      | 2.319      |
| 1529  | 0   | 1441  | 88  | 0   | 0   | GET    | /                            | 0.000 | 0.032 | 3.884   | 0.003 | 0.008 | 0.008 | 0.012 | 0.003  | 528.000    | 528.000    | 760848.000    | 497.612    |
| 872   | 0   | 732   | 140 | 0   | 0   | GET    | /assets/vendor.ee7444dd.js   | 0.004 | 0.024 | 3.392   | 0.004 | 0.008 | 0.012 | 0.016 | 0.004  | 743417.000 | 743417.000 | 544181244.000 | 624061.060 |
| 55    | 0   | 51    | 0   | 4   | 0   | POST   | /api/isu                     | 0.052 | 0.132 | 3.364   | 0.061 | 0.080 | 0.100 | 0.132 | 0.021  | 15.000     | 160.000    | 7131.000      | 129.655    |
| 871   | 0   | 732   | 139 | 0   | 0   | GET    | /assets/index.23dac98b.js    | 0.008 | 0.024 | 2.900   | 0.003 | 0.008 | 0.008 | 0.016 | 0.003  | 26667.000  | 26667.000  | 19520244.000  | 22411.302  |
| 871   | 0   | 732   | 139 | 0   | 0   | GET    | /assets/favicon.d0f5f504.svg | 0.004 | 0.028 | 2.784   | 0.003 | 0.008 | 0.008 | 0.016 | 0.003  | 592.000    | 592.000    | 433344.000    | 497.525    |
| 872   | 0   | 732   | 140 | 0   | 0   | GET    | /assets/logo_white.svg       | 0.004 | 0.024 | 2.668   | 0.003 | 0.008 | 0.008 | 0.012 | 0.003  | 3285.000   | 3285.000   | 2404620.000   | 2757.592   |
| 732   | 0   | 731   | 1   | 0   | 0   | GET    | /assets/logo_orange.svg      | 0.008 | 0.024 | 2.516   | 0.003 | 0.008 | 0.012 | 0.012 | 0.003  | 3288.000   | 3288.000   | 2403528.000   | 3283.508   |
| 872   | 0   | 733   | 139 | 0   | 0   | GET    | /assets/index.144d8ca8.css   | 0.004 | 0.028 | 2.484   | 0.003 | 0.008 | 0.008 | 0.016 | 0.003  | 19066.000  | 19066.000  | 13975378.000  | 16026.810  |
| 1     | 0   | 1     | 0   | 0   | 0   | POST   | /initialize                  | 0.204 | 0.204 | 0.204   | 0.204 | 0.204 | 0.204 | 0.204 | 0.000  | 23.000     | 23.000     | 23.000        | 23.000     |
| 50    | 0   | 30    | 20  | 0   | 0   | GET    | /isu/[0-9a-z\-]+             | 0.000 | 0.004 | 0.008   | 0.000 | 0.000 | 0.000 | 0.004 | 0.001  | 0.000      | 528.000    | 15840.000     | 316.800    |
| 3     | 0   | 1     | 2   | 0   | 0   | GET    | /register                    | 0.004 | 0.004 | 0.004   | 0.001 | 0.004 | 0.004 | 0.004 | 0.002  | 0.000      | 528.000    | 528.000       | 176.000    |
+-------+-----+-------+-----+-----+-----+--------+------------------------------+-------+-------+---------+-------+-------+-------+-------+--------+------------+------------+---------------+------------+
```